### PR TITLE
Changes because of final release of R5 (5.0.0)

### DIFF
--- a/src/Microsoft.Health.Fhir.CodeGenCommon/Models/FhirElement.cs
+++ b/src/Microsoft.Health.Fhir.CodeGenCommon/Models/FhirElement.cs
@@ -167,7 +167,7 @@ public class FhirElement : FhirPropertyBase, ICloneable
 
         IsModifier = isModifier == true;
         IsModifierReason = isModifierReason;
-        IsSummary = (isSummary == true) || (isModifier == true);
+        IsSummary = isSummary == true;
         IsMustSupport = isMustSupport == true;
         _inDifferential = false;
         IsSimple = isSimple;
@@ -445,7 +445,7 @@ public class FhirElement : FhirPropertyBase, ICloneable
 
     /// <summary>Gets the conditions.</summary>
     public HashSet<string> Conditions => _conditions;
-    
+
     /// <summary>Gets the constraints.</summary>
     public IEnumerable<FhirConstraint> Constraints { get => _constraintsByKey.Values; }
 
@@ -696,7 +696,7 @@ public class FhirElement : FhirPropertyBase, ICloneable
                 elementTypes.Add(kvp.Key, kvp.Value.DeepCopy(primitiveTypeMap));
             }
         }
-        
+
         // generate our copy
         FhirElement element = new FhirElement(
             destinationArtifact ?? RootArtifact,
@@ -829,7 +829,7 @@ public class FhirElement : FhirPropertyBase, ICloneable
         if (isComponent)
         {
             values.Add(
-                new (
+                new(
                     FhirUtils.ToConvention(Name, Path, nameConvention, concatenatePath, concatenationDelimiter),
                     FhirUtils.ToConvention(Path, string.Empty, typeConvention),
                     Name));

--- a/src/fhir-codegen-cli/Properties/launchSettings.json
+++ b/src/fhir-codegen-cli/Properties/launchSettings.json
@@ -37,12 +37,12 @@
         },
         "Firely 5.x Base": {
             "commandName": "Project",
-            "commandLineArgs": "--output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.Base\\Model --load-r5 5.0.0-snapshot3 --language CSharpFirely2 --language-options CSharpFirely2|subset=base --official-expansions-only true",
+            "commandLineArgs": "--output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.Base\\Model --load-r5 5.0.0  --language CSharpFirely2 --language-options CSharpFirely2|subset=base --official-expansions-only true",
             "workingDirectory": "$(MSBuildProjectDirectory)"
         },
         "Firely 5.x Conformance": {
             "commandName": "Project",
-            "commandLineArgs": "--output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.Conformance\\Model --load-r5 5.0.0-snapshot3 --language CSharpFirely2 --language-options CSharpFirely2|subset=conformance --official-expansions-only true",
+            "commandLineArgs": "--output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.Conformance\\Model --load-r5 5.0.0 --language CSharpFirely2 --language-options CSharpFirely2|subset=conformance --official-expansions-only true",
             "workingDirectory": "$(MSBuildProjectDirectory)"
         },
         "Firely 5.x STU3": {
@@ -62,7 +62,7 @@
         },
         "Firely 5.x R5": {
             "commandName": "Project",
-            "commandLineArgs": "--output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R5\\Model --load-r5 5.0.0-snapshot3 --language CSharpFirely2 --language-options CSharpFirely2 --include-experimental --official-expansions-only true",
+            "commandLineArgs": "--output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R5\\Model --load-r5 5.0.0 --language CSharpFirely2 --language-options CSharpFirely2 --include-experimental --official-expansions-only true",
             "workingDirectory": "$(MSBuildProjectDirectory)"
         },
         "server4-Az": {


### PR DESCRIPTION
The following changes are needed for the Firely .NET SDK 5.0 (R5):

- `IsSummary` is only dependent on the definition `IsSummary` and not in combination with `IsModifier` anymore.
- `http://hl7.org/fhir/ValueSet/constraint-severity` is placed in Template-Binding.cs although there is only 1 reference to it.
- The following attributes are introduced in R5:
   - `CapabilityStatement.identifier`
   - `CodeSystem.copyrightLabel`
   - `CodeSystem.versionAlgorithm[x]`
   - `ValueSet.copyrightLabel`
   - `ValueSet.versionAlgorithm[x]`
 - `CapabilityStatement.implementation.description` has type Markdown from R5 and higher
   