### PR TITLE
Add ICoded<T> and IIdentifiable<T> to classes.

### DIFF
--- a/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirely2.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirely2.cs
@@ -1292,6 +1292,7 @@ namespace Microsoft.Health.Fhir.SpecManager.Language
             if (primaryCodeElementInfo is not null)
             {
                 _writer.WriteLineIndented($"{primaryCodeElementInfo.PropertyType} ICoded<{primaryCodeElementInfo.PropertyType}>.Code {{ get => {primaryCodeElementInfo.PropertyName}; set => {primaryCodeElementInfo.PropertyName} = value; }}");
+                _writer.WriteLineIndented($"IEnumerable<Coding> ICoded.ToCodings() => {primaryCodeElementInfo.PropertyName}.ToCodings();");
                 _writer.WriteLine(string.Empty);
             }
 

--- a/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.SpecManager.Language
         /// <param name="value">The value.</param>
         /// <param name="isSummary">(Optional) True if is summary, false if not.</param>
         /// <param name="singleLine">(Optional) True if this is a short comment using a single line comment prefix. Implies isSummary = false.</param>
-        public static void WriteIndentedComment(ExportStreamWriter writer, string value, bool isSummary = true, bool singleLine = false)
+        public static void WriteIndentedComment(this ExportStreamWriter writer, string value, bool isSummary = true, bool singleLine = false)
         {
             if (string.IsNullOrEmpty(value))
             {


### PR DESCRIPTION
Required quite a bit of refactoring to correctly determine type of ICode<T> to implement, also for coded elements. This gave me an excuse to eliminate the duplication in WriteElement and WriteCodedElement.