### PR TITLE
Move CodeableReference to Base

### DIFF
--- a/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirely2.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirely2.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Health.Fhir.SpecManager.Language
             "Reference",
             "Signature",
             "UsageContext",
+            "CodeableReference"
         };
 
         /// <summary>


### PR DESCRIPTION
Changed code generation so CodeableReference is now part of Base.