### PR TITLE
string markdown validation pattern

### DIFF
--- a/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Health.Fhir.SpecManager.Language
             ["code"] = "CodePattern",
             ["time"] = "TimePattern",
             ["string"] = "StringPattern",
-            ["markdown"] = "MarkdownPattern"
         };
 
         /// <summary>Writes an indented comment.</summary>

--- a/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Health.Fhir.SpecManager.Language
             ["code"] = "CodePattern",
             ["time"] = "TimePattern",
             ["string"] = "StringPattern",
+            ["markdown"] = "StringPattern"
         };
 
         /// <summary>Writes an indented comment.</summary>

--- a/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Language/CSharpFirelyCommon.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Health.Fhir.SpecManager.Language
             ["oid"] = "OidPattern",
             ["code"] = "CodePattern",
             ["time"] = "TimePattern",
+            ["string"] = "StringPattern",
+            ["markdown"] = "MarkdownPattern"
         };
 
         /// <summary>Writes an indented comment.</summary>


### PR DESCRIPTION
Try running this, the result should be an added [StringPattern] attribute on Generated/FhirString.cs and ideally one on Generated/Markdown.cs (with everything else unchanged)