### PR TITLE
Generalize handling of Base/Conformance properties that changed type

### DIFF
--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirely2.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirely2.cs
@@ -3392,17 +3392,8 @@ public sealed class CSharpFirely2 : ILanguage, IFileHashTestable
                 OpenScope();
                 _writer.WriteIndented($"get {{ return {ei.PropertyName} != null ? ");
                 string propAccess = versionsRemark is not null
-                    ? $"(({mostGeneralValueAccessorType(ptr)}){ei.PropertyName})"
+                    ? $"(({MostGeneralValueAccessorType(ptr)}){ei.PropertyName})"
                     : ei.PropertyName;
-
-                static string mostGeneralValueAccessorType(PrimitiveTypeReference ptr)
-                {
-                    return ptr.ConveniencePropertyTypeString switch
-                    {
-                        "string" => "IValue<string>",
-                        _ => ptr.PropertyTypeString
-                    };
-                }
 
                 _writer.WriteLine($"{propAccess}.Value : null; }}");
                 _writer.WriteLineIndented("set");
@@ -3428,7 +3419,7 @@ public sealed class CSharpFirely2 : ILanguage, IFileHashTestable
 
                 _writer.WriteIndented($"get {{ return {ei.PropertyName} != null ? {ei.PropertyName}");
                 if(versionsRemark is not null)
-                    _writer.Write($".Cast<{lptr.PropertyTypeString}>()");
+                    _writer.Write($".Cast<{MostGeneralValueAccessorType(lptr)}>()");
                 _writer.WriteLine($".Select(elem => elem.Value) : null; }}");
 
                 _writer.WriteLineIndented("set");
@@ -3452,6 +3443,16 @@ public sealed class CSharpFirely2 : ILanguage, IFileHashTestable
                 break;
         }
     }
+
+    private static string MostGeneralValueAccessorType(PrimitiveTypeReference ptr)
+    {
+        return ptr.ConveniencePropertyTypeString switch
+        {
+            "string" => "IValue<string>",
+            _ => ptr.PropertyTypeString
+        };
+    }
+
 
     /// <summary>
     /// Determine the type name for an element that has child elements, based on the definition and

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirelyCommon.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirelyCommon.cs
@@ -17,7 +17,7 @@ public static class CSharpFirelyCommon
 {
 
     /// <summary>Dictionary mapping FHIR primitive types to language equivalents (see Template-Model.tt#1252).</summary>
-    public static readonly Dictionary<string, string> PrimitiveTypeMap = new Dictionary<string, string>()
+    public static readonly Dictionary<string, string> PrimitiveTypeMap = new()
     {
         { "base64Binary", "byte[]" },
         { "boolean", "bool?" },
@@ -251,4 +251,10 @@ public static class CSharpFirelyCommon
     {
         return (relativeOrder * 10) + 10;
     }
+}
+
+
+public static class StringHelpers
+{
+    public static string EnsurePeriod(this string s) => s.EndsWith('.') ? s : s + ".";
 }

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirelyCommon.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirelyCommon.cs
@@ -4,8 +4,12 @@
 // </copyright>
 
 using System.ComponentModel;
+using System.Text;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.CodeGen.FhirExtensions;
+using Microsoft.Health.Fhir.CodeGenCommon.Extensions;
+using Microsoft.Health.Fhir.CodeGenCommon.Packaging;
+using Microsoft.Health.Fhir.CodeGenCommon.Utils;
 
 #if NETSTANDARD2_0
 using Microsoft.Health.Fhir.CodeGenCommon.Polyfill;
@@ -250,6 +254,21 @@ public static class CSharpFirelyCommon
     public static int GetOrder(int relativeOrder)
     {
         return (relativeOrder * 10) + 10;
+    }
+
+    public static string BuildAllowedTypesAttribute(IEnumerable<TypeReference> types, FhirReleases.FhirSequenceCodes? since)
+    {
+        StringBuilder sb = new();
+        sb.Append("[AllowedTypes(");
+
+        string typesList = string.Join(",",
+            types.Select(t => $"typeof({t.PropertyTypeString})"));
+
+        sb.Append(typesList);
+        if (since is not null)
+            sb.Append($", Since = FhirRelease.{since}");
+        sb.Append(")]");
+        return sb.ToString();
     }
 }
 

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/FirelyNetIG.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/FirelyNetIG.cs
@@ -2159,9 +2159,9 @@ public partial class FirelyNetIG : ILanguage
                                 break;
                                 //throw new Exception($"Found multiple discriminators for {id}");
                             }
- 
+
                             if (discriminators.Length == 1)
-                            { 
+                            {
                                 discriminator = discriminators[0];
 
                                 bool isExtensionSlice = _findExtensionPathRegex.IsMatch(discriminator.Path);
@@ -3361,7 +3361,7 @@ public partial class FirelyNetIG : ILanguage
             remarks = (remarks == null ? string.Empty : remarks + "\n") +
                 $"Structure Definition Name: {cd.Structure.Name}";
         }
-  
+
         string directive;
         if (_info.TryGetPackageSource(cd.Structure, out string packageId, out string packageVersion))
         {

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/FirelyNetIG.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/FirelyNetIG.cs
@@ -3567,7 +3567,7 @@ public partial class FirelyNetIG : ILanguage
                         Expression = "DataType",
                     },
                     ContextTarget = null,
-                    ContextElementInfo = new("", "", "", new ChoiceTypeReference(), null),
+                    ContextElementInfo = new("", "", "", ComplexTypeReference.DataTypeReference, null),
                     //ContextElementInfo = new CSharpFirely2.WrittenElementInfo()
                     //{
                     //    ElementType = "Hl7.Fhir.Model.DataType",

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/TypeReference.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/TypeReference.cs
@@ -5,6 +5,19 @@ namespace Microsoft.Health.Fhir.CodeGen.Language.Firely;
 
 public abstract record TypeReference(string Name)
 {
+    public static TypeReference BuildFromFhirTypeName(string name, string? vsName=null, string? vsClass=null)
+    {
+        // Elements of type Code or Code<T> have their own naming/types, so handle those separately.
+        if (name == "code" && vsName is not null)
+            return new CodedTypeReference(vsName, vsClass);
+
+        if (PrimitiveTypeReference.IsFhirPrimitiveType(name))
+            return PrimitiveTypeReference.GetTypeReference(name);
+
+        // Otherwise, this is a "normal" name for a complex type.
+        return new ComplexTypeReference(name, MapTypeName(name));
+    }
+
     public abstract string PropertyTypeString { get; }
 
     internal static string MapTypeName(string name)
@@ -102,8 +115,6 @@ public record ComplexTypeReference(string Name, string PocoTypeName) : TypeRefer
 
     public static readonly ComplexTypeReference DataTypeReference = new("DataType");
 }
-
-public record ChoiceTypeReference() : ComplexTypeReference("DataType");
 
 public record CodedTypeReference(string EnumName, string? EnumClassName)
     : PrimitiveTypeReference("code", EnumName, typeof(Enum))

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/TypeReference.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/TypeReference.cs
@@ -41,6 +41,7 @@ public record PrimitiveTypeReference(string Name, string PocoTypeName, Type Conv
     public static PrimitiveTypeReference ForTypeName(string name, Type propertyType) =>
         new(name, MapTypeName(name), propertyType);
 
+    public static readonly PrimitiveTypeReference PrimitiveType = ForTypeName("PrimitiveType", typeof(object));
     public static readonly PrimitiveTypeReference Boolean = ForTypeName("boolean", typeof(bool));
     public static readonly PrimitiveTypeReference Base64Binary = ForTypeName("base64Binary", typeof(byte[]));
     public static readonly PrimitiveTypeReference Canonical = ForTypeName("canonical", typeof(string));
@@ -95,10 +96,14 @@ public record CqlTypeReference(string Name, Type PropertyType) : TypeReference(N
 
 public record ComplexTypeReference(string Name, string PocoTypeName) : TypeReference(Name)
 {
+    public ComplexTypeReference(string name) : this(name, name) { }
+
     public override string PropertyTypeString => $"Hl7.Fhir.Model.{PocoTypeName}";
+
+    public static readonly ComplexTypeReference DataTypeReference = new("DataType");
 }
 
-public record ChoiceTypeReference() : ComplexTypeReference("DataType", "DataType");
+public record ChoiceTypeReference() : ComplexTypeReference("DataType");
 
 public record CodedTypeReference(string EnumName, string? EnumClassName)
     : PrimitiveTypeReference("code", EnumName, typeof(Enum))

--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/TypeReference.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/TypeReference.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Microsoft.Health.Fhir.CodeGenCommon.Extensions;
 using Microsoft.Health.Fhir.CodeGenCommon.Utils;
 
@@ -43,27 +41,41 @@ public record PrimitiveTypeReference(string Name, string PocoTypeName, Type Conv
     public static PrimitiveTypeReference ForTypeName(string name, Type propertyType) =>
         new(name, MapTypeName(name), propertyType);
 
+    public static readonly PrimitiveTypeReference Boolean = ForTypeName("boolean", typeof(bool));
+    public static readonly PrimitiveTypeReference Base64Binary = ForTypeName("base64Binary", typeof(byte[]));
+    public static readonly PrimitiveTypeReference Canonical = ForTypeName("canonical", typeof(string));
+    public static readonly PrimitiveTypeReference Code = ForTypeName("code", typeof(string));
+    public static readonly PrimitiveTypeReference Date = ForTypeName("date", typeof(string));
+    public static readonly PrimitiveTypeReference DateTime = ForTypeName("dateTime", typeof(string));
+    public static readonly PrimitiveTypeReference Decimal = ForTypeName("decimal", typeof(decimal));
+    public static readonly PrimitiveTypeReference Id = ForTypeName("id", typeof(string));
+    public static readonly PrimitiveTypeReference Instant = ForTypeName("instant", typeof(DateTimeOffset));
+    public static readonly PrimitiveTypeReference Integer = ForTypeName("integer", typeof(int));
+    public static readonly PrimitiveTypeReference Integer64 = ForTypeName("integer64", typeof(long));
+    public static readonly PrimitiveTypeReference Oid = ForTypeName("oid", typeof(string));
+    public static readonly PrimitiveTypeReference PositiveInt = ForTypeName("positiveInt", typeof(int));
+    public static readonly PrimitiveTypeReference String = ForTypeName("string", typeof(string));
+    public static readonly PrimitiveTypeReference Time = ForTypeName("time", typeof(string));
+    public static readonly PrimitiveTypeReference UnsignedInt = ForTypeName("unsignedInt", typeof(int));
+    public static readonly PrimitiveTypeReference Uri = ForTypeName("uri", typeof(string));
+    public static readonly PrimitiveTypeReference Url = ForTypeName("url", typeof(string));
+    public static readonly PrimitiveTypeReference Xhtml = ForTypeName("xhtml", typeof(string));
+    public static readonly PrimitiveTypeReference Markdown = ForTypeName("markdown", typeof(string));
+
     public static readonly IReadOnlyCollection<PrimitiveTypeReference> PrimitiveList =
     [
-        ForTypeName("base64Binary", typeof(byte[])), ForTypeName("boolean", typeof(bool)),
-        ForTypeName("canonical", typeof(string)), ForTypeName("code", typeof(string)),
-        ForTypeName("date", typeof(string)), ForTypeName("dateTime", typeof(string)),
-        ForTypeName("decimal", typeof(decimal)), ForTypeName("id", typeof(string)),
-        ForTypeName("instant", typeof(DateTimeOffset)), ForTypeName("integer", typeof(int)),
-        ForTypeName("integer64", typeof(long)), ForTypeName("oid", typeof(string)),
-        ForTypeName("positiveInt", typeof(int)), ForTypeName("string", typeof(string)),
-        ForTypeName("time", typeof(string)), ForTypeName("unsignedInt", typeof(int)),
-        ForTypeName("uri", typeof(string)), ForTypeName("url", typeof(string)),
-        ForTypeName("xhtml", typeof(string)), ForTypeName("markdown", typeof(string))
+        Boolean, Base64Binary, Canonical, Code, Date, DateTime, Decimal, Id,
+        Instant, Integer, Integer64, Oid, PositiveInt, String, Time, UnsignedInt,
+        Uri, Url, Xhtml, Markdown
     ];
 
-    private static readonly Dictionary<string, PrimitiveTypeReference> s_primitiveDictionary =
+    private static readonly Dictionary<string, PrimitiveTypeReference> _primitiveDictionary =
         PrimitiveList.ToDictionary(ptr => ptr.Name);
 
-    public static bool IsFhirPrimitiveType(string name) => s_primitiveDictionary.ContainsKey(name);
+    public static bool IsFhirPrimitiveType(string name) => _primitiveDictionary.ContainsKey(name);
 
     public static PrimitiveTypeReference GetTypeReference(string name) =>
-        s_primitiveDictionary.TryGetValue(name, out var tr)
+        _primitiveDictionary.TryGetValue(name, out var tr)
             ? tr
             : throw new InvalidOperationException($"Unknown FHIR primitive {name}");
 

--- a/src/Microsoft.Health.Fhir.CodeGenCommon/Extensions/FhirNameConventionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CodeGenCommon/Extensions/FhirNameConventionExtensions.cs
@@ -95,7 +95,7 @@ public static class FhirNameConventionExtensions
             return string.Join(joinDelimiter, word.Split(delimitersToRemove, _wordSplitOptions).Select(w => w.ToPascalCase(false)));
         }
 
-        return string.Concat(word.Substring(0, 1).ToUpperInvariant(), word.Substring(1));
+        return string.Concat(word[..1].ToUpperInvariant(), word[1..]);
     }
 
     /// <summary>An extension method that converts an array of words each to PascalCase.</summary>
@@ -163,10 +163,10 @@ public static class FhirNameConventionExtensions
         {
             // converting to pascal and changing the initial letter is faster than accumulating here
             string pc = word.ToPascalCase(removeDelimiters, joinDelimiter, delimitersToRemove);
-            return string.Concat(pc.Substring(0, 1).ToLowerInvariant(), pc.Substring(1));
+            return string.Concat(pc[..1].ToLowerInvariant(), pc[1..]);
         }
 
-        return string.Concat(word.Substring(0, 1).ToLowerInvariant(), word.Substring(1));
+        return string.Concat(word[..1].ToLowerInvariant(), word[1..]);
     }
 
     /// <summary>An extension method that converts an array of words each to camelCase.</summary>


### PR DESCRIPTION
This change makes sure that, in base/conformance, if we have a (primitive) property that changed type from version to version (like Attachment.size), the property is now of the abstract subclass PrimitiveType. (this PR actually would handle non-primitives too, but there isn't yet anything to test that with).

For such elements:
* The element changed type from whatever we picked (e.g. `Integer64` for Attachtment.size) to a base class (in the case of primitive properties, to `PrimitiveType`)
* There will be helper properties with the correct type for each version. The most current will have the normal element name (Size in this case), while the older one(s) will have the FHIR type appended to them (SizeUnsignedInt).
* The documentation for the properties will make it clear when to use which property.

Note that the generated code is smart enough to know that, when generating helper getters, the actual type of the backing element does not matter, as long as they have the same .NET primitive constants.  In all other cases, the helper getters will throw if the backing element has the wrong type.

The setters for the helper properties will always create the correct type in the backing element property.

E.g. if we're talking about `Attachment.size`, the accessor returning a `long` requires the `SizeElement` to be a FHIR Integer64. If it encounters an UnsignedInt there, the getter will throw.  But for `ElementDefinition.description`, the getter of both versions (one for markdown one for FHIR string) will work, as both `Markdown` and `FhirString` have a `string` in their `Value` property.

I have also added `[AllowedTypes]` to such changed properties, as the abstract property type allows too many types. Obviously, the allowedtypes are exactly the sum of the types declared per version. We could make this validation more precise, if the validation attributes would be sensitive to FHIR version, which they are not yet. I have created an isse (https://github.com/FirelyTeam/firely-net-sdk/issues/2982) to fix this in the future. For now, I generate these attributes with a "since" as comment lines.

To be able to generate these `[AllowedTypes]` attributes, I had to refactor the code a bit to avoid re-duplicating the existing code that generates this attribute for choicetypes.
