### PR TITLE
Removed Bw-compat code

### DIFF
--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/FirelyNetIG.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/FirelyNetIG.cs
@@ -724,7 +724,7 @@ public partial class FirelyNetIG : ILanguage
         foreach ((string unversionedUrl, string[] versions) in _info.ValueSetVersions.OrderBy(kvp => kvp.Key))
         {
             // check for exclusions
-            if (CSharpFirely2._exclusionSet.Contains(unversionedUrl))
+            if (CSharpFirely2.ExclusionSet.Contains(unversionedUrl))
             {
                 continue;
             }
@@ -808,7 +808,7 @@ public partial class FirelyNetIG : ILanguage
 
         // Enums and their containing classes cannot have the same name,
         // so we have to correct these here
-        if (CSharpFirely2._enumNamesOverride.TryGetValue(vs.Url, out var replacementName))
+        if (CSharpFirely2.EnumNamesOverride.TryGetValue(vs.Url, out var replacementName))
         {
             nameSanitized = replacementName;
         }


### PR DESCRIPTION
The codegen had some code to keep on generating divergent names for enums, components, types etcetera, which were once generated in error but that we could not correct until we are publishing a new major release. Now is the time.