### PR TITLE
Changes to be able to generate FHIR R6.

### DIFF
--- a/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirely2.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Language/Firely/CSharpFirely2.cs
@@ -420,18 +420,20 @@ public sealed class CSharpFirely2 : ILanguage, IFileHashTestable
         }
 
         // only generate base definitions for R5
-        if (subset.HasFlag(GenSubset.Base) && info.FhirSequence != FhirReleases.FhirSequenceCodes.R5)
+        if (subset.HasFlag(GenSubset.Base) &&
+            info.FhirSequence is not (FhirReleases.FhirSequenceCodes.R6 or FhirReleases.FhirSequenceCodes.R5))
         {
-            Console.WriteLine($"Aborting {LanguageName} for {info.FhirSequence}: code generation for the 'base' subset should be run on R5 only.");
+            Console.WriteLine($"Aborting {LanguageName} for {info.FhirSequence}: code generation for the 'base' subset should be run on R5/R6 only.");
             return;
         }
 
         // conformance subset is only valid for STU3 and R5
         if (subset.HasFlag(GenSubset.Conformance) &&
-            (info.FhirSequence != FhirReleases.FhirSequenceCodes.STU3 &&
-            info.FhirSequence != FhirReleases.FhirSequenceCodes.R5))
+            info.FhirSequence is not (FhirReleases.FhirSequenceCodes.STU3 or
+                FhirReleases.FhirSequenceCodes.R5 or FhirReleases.FhirSequenceCodes.R6))
+
         {
-            Console.WriteLine($"Aborting {LanguageName} for {info.FhirSequence}: code generation for the 'conformance' subset should be run on STU3 or R5 only.");
+            Console.WriteLine($"Aborting {LanguageName} for {info.FhirSequence}: code generation for the 'conformance' subset should be run on STU3 or R5/R6 only.");
             return;
         }
 
@@ -936,6 +938,13 @@ public sealed class CSharpFirely2 : ILanguage, IFileHashTestable
 
             foreach (SearchParameter sp in resourceSearchParams.Values.OrderBy(s => s.Name))
             {
+                // TODO:R6: Add support for the 'resource' search parameter type
+                if ((sp.TypeElement.ObjectValue is "resource"))
+                {
+                    Console.WriteLine($"Skipping SearchParameter {sp.Id} ({sp.Url}) because it is target type of 'resource'!!!");
+                    continue;
+                }
+
                 if (sp.Experimental == true)
                 {
                     continue;

--- a/src/Microsoft.Health.Fhir.CodeGen/Loader/PackageLoader.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Loader/PackageLoader.cs
@@ -126,7 +126,7 @@ public class PackageLoader : IDisposable
 
         _defaultFhirVersion = FhirReleases.FhirVersionToSequence(_rootConfiguration.FhirVersion);
 
-        _jsonOptions = opts.FhirJsonOptions;
+        _jsonOptions = opts.FhirJsonOptions.UsingMode(DeserializerModes.Ostrich);
         _jsonParser = new(opts.FhirJsonSettings);
 
 #if !DISABLE_XML

--- a/src/Microsoft.Health.Fhir.CodeGen/Models/DefinitionCollection.cs
+++ b/src/Microsoft.Health.Fhir.CodeGen/Models/DefinitionCollection.cs
@@ -854,8 +854,14 @@ public partial class DefinitionCollection
                 fo = outFieldOrder.Count + 1;
                 outFieldOrder.Add(pc.Name, fo);
             }
-            else 
+            else
             {
+                if (inFieldOrder.ContainsKey(pc.Name))
+                {
+                    Console.WriteLine($"Operation: {op.Id} ({op.Url}) defines the parameter {pc.Name} more than once!!!");
+                    continue;
+                }
+
                 fo = inFieldOrder.Count + 1;
                 inFieldOrder.Add(pc.Name, fo);
             }

--- a/src/Microsoft.Health.Fhir.CodeGenCommon/Packaging/FhirReleases.cs
+++ b/src/Microsoft.Health.Fhir.CodeGenCommon/Packaging/FhirReleases.cs
@@ -37,7 +37,7 @@ public static class FhirReleases
         /// <summary>FHIR R5.</summary>
         R5 = 5,
 
-        /// <summary>FHIR R5.</summary>
+        /// <summary>FHIR R6.</summary>
         R6 = 6,
     }
 

--- a/src/fhir-codegen/Properties/launchSettings.json
+++ b/src/fhir-codegen/Properties/launchSettings.json
@@ -35,9 +35,19 @@
             "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R5\\Model -p hl7.fhir.r5.core#5.0.0 -p hl7.fhir.r5.expansions#5.0.0 --subset satellite",
             "workingDirectory": "$(MSBuildProjectDirectory)"
         },
-        "Firely 5.x R6": {
+        "NEW Firely 5.x R6": {
             "commandName": "Project",
-            "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R6\\Model -p hl7.fhir.r6.core#6.0.0-ballot2 -p hl7.fhir.r6.expansions#6.0.0-ballot2 --subset satellite",
+            "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R6\\Model -p hl7.fhir.r6.core#6.0.0-ballot3 -p hl7.fhir.r6.expansions#6.0.0-ballot3 --subset satellite",
+            "workingDirectory": "$(MSBuildProjectDirectory)"
+        },
+         "NEW Firely 6.x Base": {
+            "commandName": "Project",
+            "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.Base\\Model -p hl7.fhir.r6.core#6.0.0-ballot3 -p hl7.fhir.r6.expansions#6.0.0-ballot3 --subset base",
+            "workingDirectory": "$(MSBuildProjectDirectory)"
+        },
+        "NEW Firely 6.x Conformance": {
+            "commandName": "Project",
+            "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.Conformance\\Model -p hl7.fhir.r6.core#6.0.0-ballot3 -p hl7.fhir.r6.expansions#6.0.0-ballot3 --subset conformance",
             "workingDirectory": "$(MSBuildProjectDirectory)"
         },
         "Firely IG Backport": {

--- a/src/fhir-codegen/Properties/launchSettings.json
+++ b/src/fhir-codegen/Properties/launchSettings.json
@@ -35,7 +35,7 @@
             "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R5\\Model -p hl7.fhir.r5.core#5.0.0 -p hl7.fhir.r5.expansions#5.0.0 --subset satellite",
             "workingDirectory": "$(MSBuildProjectDirectory)"
         },
-        "NEW Firely 5.x R6": {
+        "NEW Firely 6.x R6": {
             "commandName": "Project",
             "commandLineArgs": "generate CSharpFirely2 --output-path ..\\..\\..\\firely-net-sdk\\src\\Hl7.Fhir.R6\\Model -p hl7.fhir.r6.core#6.0.0-ballot3 -p hl7.fhir.r6.expansions#6.0.0-ballot3 --subset satellite",
             "workingDirectory": "$(MSBuildProjectDirectory)"


### PR DESCRIPTION
These are the changes to the generator so we can run FHIR R6 generation. Note that we have no support for the "resoure" search param type yet. Also, there are mistakes in ballot3 for insummary and there is an operation with a duplicate searchparam. Also, we cannot yet use R6 for generating Base + Conformance (insummary, changed location of some enums, strings turned into markdown.).

But at least, we will have the code in the generator, so we can play with R6 when we need it.